### PR TITLE
chore: use File.separator in other tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## About
 
-You are are community leader? *Komunumo* makes your life a lot easier! Eveything you need to run your community in one place, for free! *Komunumo* is an open source community manager software which assists you in all tasks managing a community like a user group or a meetup.
+You are a community leader? *Komunumo* makes your life a lot easier! Eveything you need to run your community in one place, for free! *Komunumo* is an open source community manager software which assists you in all tasks managing a community like a user group or a meetup.
 
 With *Komunumo* you can manage your community members (including self-management), organize events (including registration), send out newsletters, manage your sponsors, and a lot more.
 

--- a/src/test/java/app/komunumo/ui/website/community/CommunityGridViewIT.java
+++ b/src/test/java/app/komunumo/ui/website/community/CommunityGridViewIT.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.File;
+
 class CommunityGridViewIT extends BrowserTest {
 
     @Test
@@ -56,7 +58,7 @@ class CommunityGridViewIT extends BrowserTest {
                 final var imageSrc = image.getAttribute("src");
                 assertThat(imageSrc)
                         .as("expected to contain an image but was: " + imageSrc)
-                        .startsWith("/images/")
+                        .startsWith(File.separator + "images" + File.separator)
                         .endsWith(".jpg")
                         .doesNotContain("placeholder");
 

--- a/src/test/java/app/komunumo/ui/website/home/UpcomingEventsIT.java
+++ b/src/test/java/app/komunumo/ui/website/home/UpcomingEventsIT.java
@@ -20,6 +20,7 @@ package app.komunumo.ui.website.home;
 import app.komunumo.ui.BrowserTest;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -62,7 +63,7 @@ class UpcomingEventsIT extends BrowserTest {
                 final var imageSrc = image.getAttribute("src");
                 assertThat(imageSrc)
                         .as("expected to contain an image but was: " + imageSrc)
-                        .startsWith("/images/")
+                        .startsWith(File.separator + "images" + File.separator)
                         .endsWith(".jpg")
                         .doesNotContain("placeholder");
 


### PR DESCRIPTION
Sorry, I did not look at the entire test output last time, that is why I missed these 2 tests. After this, all tests were passing on a Windows machine.