### PR TITLE
feat: add compatibility with Colima for local development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -245,6 +245,39 @@ If you use Podman Desktop for macOS, activate the full Docker compatibility laye
 4. Click on the new entry "Docker Compatibility".
 5. Make sure, "Third-Party Docker Tool Compatibility" is *activated*.
 
+#### Using Colima on macOS
+
+[Colima](https://github.com/abiosoft/colima) can be used instead of Docker Desktop/Podman.
+Install Colima and the Docker CLI, then start the default Colima instance:
+
+```bash
+brew install colima docker
+colima start
+docker context use colima
+```
+
+Verify that Docker commands are routed to Colima:
+
+```bash
+docker version
+docker context inspect colima
+```
+
+When running Maven goals that use Testcontainers, enable the `colima` Maven profile:
+
+```bash
+./mvnw -Pcolima verify
+```
+
+The profile configures Testcontainers for the default Colima socket at `${user.home}/.colima/default/docker.sock` and sets the container-internal Docker socket override to `/var/run/docker.sock`.
+If you use a non-default Colima instance, override the socket path explicitly:
+
+```bash
+./mvnw -Pcolima \
+  -Dtestcontainers.docker.host=unix://${HOME}/.colima/YOUR_INSTANCE/docker.sock \
+  verify
+```
+
 ### Clone and Verify
 
 1. Fork the [Komunumo repository](https://github.com/komunumo/komunumo) on GitHub.
@@ -259,6 +292,12 @@ If you use Podman Desktop for macOS, activate the full Docker compatibility laye
 
    ```bash
    ./mvnw verify
+   ```
+
+   If you use Colima on macOS, run:
+
+   ```bash
+   ./mvnw -Pcolima verify
    ```
 
 ### Start Required Services

--- a/pom.xml
+++ b/pom.xml
@@ -644,7 +644,7 @@
                             <enableAssertions>true</enableAssertions>
 
                             <!-- Ensure no browser auto-download happens inside forked JVMs -->
-                            <environmentVariables>
+                            <environmentVariables combine.children="append">
                                 <PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD>1</PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD>
                                 <PLAYWRIGHT_BROWSERS_PATH>${user.home}/.cache/ms-playwright</PLAYWRIGHT_BROWSERS_PATH>
                             </environmentVariables>
@@ -940,6 +940,46 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>colima</id>
+            <properties>
+                <testcontainers.docker.host>unix://${user.home}/.colima/default/docker.sock</testcontainers.docker.host>
+                <testcontainers.host.override>localhost</testcontainers.host.override>
+                <testcontainers.docker.socket.override>/var/run/docker.sock</testcontainers.docker.socket.override>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>jooq-codegen-forked</id>
+                                <configuration>
+                                    <environmentVariables>
+                                        <DOCKER_HOST>${testcontainers.docker.host}</DOCKER_HOST>
+                                        <TESTCONTAINERS_HOST_OVERRIDE>${testcontainers.host.override}</TESTCONTAINERS_HOST_OVERRIDE>
+                                        <TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE>${testcontainers.docker.socket.override}</TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE>
+                                    </environmentVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <environmentVariables combine.children="append">
+                                <DOCKER_HOST>${testcontainers.docker.host}</DOCKER_HOST>
+                                <TESTCONTAINERS_HOST_OVERRIDE>${testcontainers.host.override}</TESTCONTAINERS_HOST_OVERRIDE>
+                                <TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE>${testcontainers.docker.socket.override}</TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE>
+                            </environmentVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
         <profile>
             <id>playwright-linux-deps</id>
             <!-- Activate only on Linux (Ubuntu runners included).


### PR DESCRIPTION
## What Changed

This adds a `colima` Maven profile for local development with Colima on macOS.

- Configures Testcontainers with the default Colima Docker socket.
- Sets the container-internal Docker socket override expected by Testcontainers.
- Preserves existing Playwright environment variables when the Colima profile is active.
- Documents the Colima setup and `./mvnw -Pcolima verify` workflow.

## Why

This makes it possible to run the local verification workflow on machines that use Colima instead of Docker Desktop or Podman.
Without these settings, Testcontainers fails to connect to the Docker daemon and reports that no valid Docker environment was found.

This was implemented during the Hackergarten in April in Basel.

## Testing

- Verified with `./mvnw -Pcolima verify` on a Colima setup.

## AI Disclosure

This PR description was drafted with Codex assistance and reviewed before submission.

## DCO Notice

All commits include `Signed-off-by:` via `git commit -s`. This is a legal attestation the contributor must make personally.
