### PR TITLE
docs: add Testcontainers troubleshooting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -245,6 +245,12 @@ If you use Podman Desktop for macOS, activate the full Docker compatibility laye
 4. Click on the new entry "Docker Compatibility".
 5. Make sure, "Third-Party Docker Tool Compatibility" is *activated*.
 
+#### Testcontainers Troubleshooting
+
+Testcontainers can read global settings from `~/.testcontainers.properties`. These settings apply to all projects and Docker-compatible runtimes.
+
+If tests fail because Testcontainers cannot connect to Docker, Podman, or another Docker-compatible runtime, check whether that file contains stale `docker.host` or `tc.host` values. Remove outdated entries unless you intentionally need a global override. Prefer project-specific environment variables or Maven profiles where possible.
+
 ### Clone and Verify
 
 1. Fork the [Komunumo repository](https://github.com/komunumo/komunumo) on GitHub.


### PR DESCRIPTION
## What Changed

This adds a short Testcontainers troubleshooting section to `CONTRIBUTING.md`.

It explains that `~/.testcontainers.properties` is global Testcontainers configuration and that stale `docker.host` or `tc.host` values can affect Docker Desktop, Podman, Colima, or other Docker-compatible runtimes.

## Why

This helps contributors diagnose local test failures caused by old global Testcontainers settings rather than project-specific configuration.

This was implemented during the Hackergarten in April in Basel.

## Testing

Not run. This is a documentation-only change.

## AI Disclosure

This PR description was drafted with Codex assistance and reviewed before submission.

## DCO Notice

All commits include `Signed-off-by:` via `git commit -s`. This is a legal attestation the contributor must make personally.
