### PR TITLE
feat(dev): local-stack Maven profile and ARM-compatible container images

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -389,6 +389,18 @@ You can run *Komunumo* either via your IDE or the command line. On the command l
 
 This runs the `app.komunumo.Application` main class.
 
+If you want to use local defaults from `application-local.properties` (database, mail, demo mode, admin), activate the `local` Spring profile:
+
+```bash
+SPRING_PROFILES_ACTIVE=local ./mvnw
+```
+
+To start the complete local stack in one command (Docker Compose services from `dev-tools` + application with `local` profile), use:
+
+```bash
+./mvnw -Plocal-stack
+```
+
 ### Open in Browser
 
 Once the application is running, open your browser and navigate to:
@@ -583,6 +595,7 @@ To start a local MariaDB instance using [Docker](https://www.docker.com/) or [Po
 | Command          | What it does                                                      |
 |------------------|-------------------------------------------------------------------|
 | `./mvnw`         | compile and run the app                                           |
+| `./mvnw -Plocal-stack` | start local docker stack and run app with `local` profile  |
 | `./mvnw clean`   | cleanup generated files and build artefacts                       |
 | `./mvnw compile` | compile the code without running the tests                        |
 | `./mvnw test`    | compile and run all tests                                         |

--- a/dev-tools/docker-compose.yaml
+++ b/dev-tools/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
         target: /var/lib/mysql
 
   phpmyadmin:
-    image: docker.io/phpmyadmin/phpmyadmin:latest
+    image: docker.io/linuxserver/phpmyadmin:latest
     container_name: phpmyadmin
     restart: unless-stopped
     ports:
@@ -33,7 +33,7 @@ services:
       - mariadb
 
   mailpit:
-    image: docker.io/axllent/mailpit
+    image: docker.io/axllent/mailpit:v1.27
     container_name: mailpit
     restart: unless-stopped
     ports:

--- a/pom.xml
+++ b/pom.xml
@@ -941,6 +941,39 @@
 
     <profiles>
         <profile>
+            <id>local-stack</id>
+            <properties>
+                <spring-boot.run.profiles>local</spring-boot.run.profiles>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>local-stack-compose-up</id>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>docker</executable>
+                                    <workingDirectory>${project.basedir}/dev-tools</workingDirectory>
+                                    <arguments>
+                                        <argument>compose</argument>
+                                        <argument>up</argument>
+                                        <argument>-d</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
             <id>colima</id>
             <properties>
                 <testcontainers.docker.host>unix://${user.home}/.colima/default/docker.sock</testcontainers.docker.host>

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,0 +1,12 @@
+# E-Mail
+spring.mail.host=localhost
+spring.mail.port=1025
+
+# Database
+spring.datasource.url=jdbc:mariadb://localhost:3306/komunumo?serverTimezone=Europe/Berlin&allowMultiQueries=true
+spring.datasource.username=komunumo
+spring.datasource.password=komunumo
+
+# Application specific configuration
+komunumo.demo.enabled=true
+komunumo.instance.admin=admin@example.com


### PR DESCRIPTION
## Summary
- add Maven profile local-stack to run docker compose up -d in dev-tools before app startup
- run Spring Boot with local profile via Maven property in that profile
- add application-local.properties for local DB/mail/demo/admin defaults
- document one-command local stack startup in CONTRIBUTING
- switch dev-tools images to ARM-compatible options for local development (linuxserver/phpmyadmin, axllent/mailpit:v1.27)

## How to test
- run ./mvnw -Plocal-stack
- verify app at http://localhost:8080
- verify compose services are up in dev-tools
