### PR TITLE
feat: add configurable privacy and impressum links

### DIFF
--- a/src/main/java/app/komunumo/domain/core/config/entity/ConfigurationSetting.java
+++ b/src/main/java/app/komunumo/domain/core/config/entity/ConfigurationSetting.java
@@ -62,7 +62,17 @@ public enum ConfigurationSetting {
     /**
      * <p>Whether to allow account registration or not.</p>
      */
-    INSTANCE_REGISTRATION_ALLOWED("instance.registrationAllowed", false, "true");
+    INSTANCE_REGISTRATION_ALLOWED("instance.registrationAllowed", false, "true"),
+
+    /**
+     * <p>URL to the privacy policy page.</p>
+     */
+    INSTANCE_PRIVACY_URL("instance.privacyUrl", false, ""),
+
+    /**
+     * <p>URL to the imprint/legal notice page.</p>
+     */
+    INSTANCE_IMPRINT_URL("instance.imprintUrl", false, "");
 
     /**
      * <p>The unique key identifying this configuration setting.</p>

--- a/src/main/java/app/komunumo/infra/ui/vaadin/layout/PageFooter.java
+++ b/src/main/java/app/komunumo/infra/ui/vaadin/layout/PageFooter.java
@@ -17,24 +17,45 @@
  */
 package app.komunumo.infra.ui.vaadin.layout;
 
+import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Anchor;
 import com.vaadin.flow.component.html.AnchorTarget;
 import com.vaadin.flow.component.html.Footer;
+import com.vaadin.flow.dom.Element;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.time.Year;
 
 public final class PageFooter extends Footer {
 
     public PageFooter(final @NotNull UI ui,
-                      final @NotNull String version) {
+                      final @NotNull String version,
+                      final @Nullable String privacyUrl,
+                      final @Nullable String imprintUrl) {
         super();
         addClassName("page-footer");
 
         final var komunumoFooter = ui.getTranslation("vaadin.components.PageFooter.komunumo",
                 version, String.valueOf(Year.now().getValue()));
         add(new Anchor("https://komunumo.app/", komunumoFooter, AnchorTarget.BLANK));
+
+        if (privacyUrl != null && !privacyUrl.isEmpty()) {
+            getElement().appendChild(new Element("br"));
+            final var privacyText = ui.getTranslation("vaadin.components.PageFooter.privacy");
+            add(new Anchor(privacyUrl, privacyText, AnchorTarget.BLANK));
+        }
+
+        if (imprintUrl != null && !imprintUrl.isEmpty()) {
+            if (privacyUrl != null && !privacyUrl.isEmpty()) {
+                add(new Text(" | "));
+            } else {
+                getElement().appendChild(new Element("br"));
+            }
+            final var imprintText = ui.getTranslation("vaadin.components.PageFooter.imprint");
+            add(new Anchor(imprintUrl, imprintText, AnchorTarget.BLANK));
+        }
     }
 
 }

--- a/src/main/java/app/komunumo/infra/ui/vaadin/layout/WebsiteLayout.java
+++ b/src/main/java/app/komunumo/infra/ui/vaadin/layout/WebsiteLayout.java
@@ -43,6 +43,8 @@ import org.slf4j.LoggerFactory;
 
 import static app.komunumo.domain.core.config.entity.ConfigurationSetting.INSTANCE_NAME;
 import static app.komunumo.domain.core.config.entity.ConfigurationSetting.INSTANCE_SLOGAN;
+import static app.komunumo.domain.core.config.entity.ConfigurationSetting.INSTANCE_PRIVACY_URL;
+import static app.komunumo.domain.core.config.entity.ConfigurationSetting.INSTANCE_IMPRINT_URL;
 
 @AnonymousAllowed
 public final class WebsiteLayout extends Div implements RouterLayout, BeforeEnterObserver {
@@ -77,7 +79,9 @@ public final class WebsiteLayout extends Div implements RouterLayout, BeforeEnte
         add(main);
 
         final var komunumoVersion = appConfig.version();
-        add(new PageFooter(ui, komunumoVersion));
+        final var privacyUrl = configurationService.getConfiguration(INSTANCE_PRIVACY_URL);
+        final var imprintUrl = configurationService.getConfiguration(INSTANCE_IMPRINT_URL);
+        add(new PageFooter(ui, komunumoVersion, privacyUrl, imprintUrl));
     }
 
     private void addPageHeader(final @NotNull ConfigurationService configurationService) {

--- a/src/main/resources/vaadin-i18n/translations.properties
+++ b/src/main/resources/vaadin-i18n/translations.properties
@@ -192,4 +192,6 @@ vaadin.components.NavigationBar.register=Register
 vaadin.components.NavigationBar.settings=Settings
 vaadin.components.NavigationBar.toggleDarkMode=Toggle Dark Mode
 vaadin.components.PageFooter.komunumo=Built with ❤️ and Komunumo · Version {0} · Licensed under the AGPLv3 · Copyright © {1}
+vaadin.components.PageFooter.privacy=Privacy
+vaadin.components.PageFooter.imprint=Imprint
 vaadin.components.PersistentNotification.close=Close

--- a/src/main/resources/vaadin-i18n/translations_de.properties
+++ b/src/main/resources/vaadin-i18n/translations_de.properties
@@ -194,4 +194,6 @@ vaadin.components.NavigationBar.register=Registrieren
 vaadin.components.NavigationBar.settings=Einstellungen
 vaadin.components.NavigationBar.toggleDarkMode=Dark Mode umschalten
 vaadin.components.PageFooter.komunumo=Erstellt mit ❤️ und Komunumo · Version {0} · Lizenziert unter der AGPLv3 · Copyright © {1}
+vaadin.components.PageFooter.privacy=Datenschutz
+vaadin.components.PageFooter.imprint=Impressum
 vaadin.components.PersistentNotification.close=Schliessen

--- a/src/test/java/app/komunumo/domain/core/config/entity/ConfigurationSettingTest.java
+++ b/src/test/java/app/komunumo/domain/core/config/entity/ConfigurationSettingTest.java
@@ -54,4 +54,26 @@ class ConfigurationSettingTest {
         assertThat(ConfigurationSetting.INSTANCE_SLOGAN.isLanguageDependent()).isTrue();
     }
 
+    @Test
+    void fromString_privacyUrl() {
+        assertThat(ConfigurationSetting.fromString("instance.privacyUrl"))
+                .isEqualTo(ConfigurationSetting.INSTANCE_PRIVACY_URL);
+    }
+
+    @Test
+    void fromString_imprintUrl() {
+        assertThat(ConfigurationSetting.fromString("instance.imprintUrl"))
+                .isEqualTo(ConfigurationSetting.INSTANCE_IMPRINT_URL);
+    }
+
+    @Test
+    void privacyUrl_notLanguageDependent() {
+        assertThat(ConfigurationSetting.INSTANCE_PRIVACY_URL.isLanguageDependent()).isFalse();
+    }
+
+    @Test
+    void imprintUrl_notLanguageDependent() {
+        assertThat(ConfigurationSetting.INSTANCE_IMPRINT_URL.isLanguageDependent()).isFalse();
+    }
+
 }


### PR DESCRIPTION
Add configurable privacy and imprint links to the footer. Instances can now set URLs for privacy policy and imprint pages in the database configuration. The links appear on a new line in the footer.